### PR TITLE
fix: override ChatGPT table margins and enforce dynamic wrapper width

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,54 +1,54 @@
 const saveSettings = (widthValue) => {
-    try {
-        browser.storage.local.set({ width: widthValue }).then(() => {
-            console.debug(`WideGPT: Settings saved - width: ${widthValue}%`)
-        });
-    } catch (error) {
-        console.error("WideGPT: Error saving settings:", error);
-    }
+  try {
+    browser.storage.local.set({ width: widthValue }).then(() => {
+      console.debug(`WideGPT: Settings saved - width: ${widthValue}%`);
+    });
+  } catch (error) {
+    console.error("WideGPT: Error saving settings:", error);
+  }
 };
 
 // Load settings from browser storage
 const loadSettings = () => {
-    try {
-        const result = browser.storage.local.get("width").then((result) => {
-            const widthValue = result.width || 95; // Default to 95% if not set
-            console.debug(`WideGPT: Settings loaded - width: ${widthValue}%`);
-            return widthValue;
-        });
-        return result;
-    } catch (error) {
-        console.error("WideGPT: Error loading settings:", error);
-        return 95; // Default width in case of error
-    }
+  try {
+    const result = browser.storage.local.get("width").then((result) => {
+      const widthValue = result.width || 95; // Default to 95% if not set
+      console.debug(`WideGPT: Settings loaded - width: ${widthValue}%`);
+      return widthValue;
+    });
+    return result;
+  } catch (error) {
+    console.error("WideGPT: Error loading settings:", error);
+    return 95; // Default width in case of error
+  }
 };
 
 // Function to attach or update a dynamic style rule
-const attachOrUpdateStyleRule = (css, id = 'dynamic-style') => {
-    // Check if a style element with the given ID already exists
-    let style = document.getElementById(id);
-    if (!style) {
-        // Create a new style element if it doesn't exist
-        style = document.createElement('style');
-        style.type = 'text/css';
-        style.id = id;
-        document.head.appendChild(style);
-    }
+const attachOrUpdateStyleRule = (css, id = "dynamic-style") => {
+  // Check if a style element with the given ID already exists
+  let style = document.getElementById(id);
+  if (!style) {
+    // Create a new style element if it doesn't exist
+    style = document.createElement("style");
+    style.type = "text/css";
+    style.id = id;
+    document.head.appendChild(style);
+  }
 
-    // Update the CSS content
-    if (style.styleSheet) {
-        style.styleSheet.cssText = css;
-    } else {
-        style.textContent = css;
-    }
+  // Update the CSS content
+  if (style.styleSheet) {
+    style.styleSheet.cssText = css;
+  } else {
+    style.textContent = css;
+  }
 };
 
 // Function to dynamically update the CSS rules
 const adjustMaxWidth = (width = 100) => {
-    console.debug(`WideGPT.adjustMaxWidth() called with width: ${width}%`);
+  console.debug(`WideGPT.adjustMaxWidth() called with width: ${width}%`);
 
-    // Dynamically create CSS rules using the specified width
-    const css = `
+  // Dynamically create CSS rules using the specified width
+  const css = `
         @media (min-width: 1280px) {
             .xl\\:max-w-\\[48rem\\] {
                 max-width: ${width}% !important;
@@ -77,26 +77,37 @@ const adjustMaxWidth = (width = 100) => {
                 --thread-content-max-width: ${width}% !important;
             }
         }
+
+        /* Override table container margins added by ChatGPT */
+        div[class^='_tableContainer'] {
+            --thread-content-width: unset !important;
+        }
+
+        /* Ensure table wrapper matches selected width */
+        div[class^='_tableWrapper'] {
+            min-width: fit-content !important;
+            max-width: ${width}% !important;
+        }
     `;
-    attachOrUpdateStyleRule(css);
+  attachOrUpdateStyleRule(css);
 };
 
 // Initial call with default width
 loadSettings().then((widthValue) => {
-    const widthInput = document.getElementById("widthinput")
-    if (widthInput) {
-        widthInput.value = widthValue; // Set the input field to the loaded value
-    }
-    adjustMaxWidth(widthValue);
+  const widthInput = document.getElementById("widthinput");
+  if (widthInput) {
+    widthInput.value = widthValue; // Set the input field to the loaded value
+  }
+  adjustMaxWidth(widthValue);
 });
 
 // Add an event listener to the width input field
 const widthInput = document.getElementById("widthinput");
 if (widthInput) {
-    widthInput.addEventListener("input", () => {
-        const widthValue = widthInput.value;
-        console.debug(`WideGPT: Width input changed to: ${widthValue}%`);
-        adjustMaxWidth(widthValue);
-        saveSettings(widthValue);
-    });
+  widthInput.addEventListener("input", () => {
+    const widthValue = widthInput.value;
+    console.debug(`WideGPT: Width input changed to: ${widthValue}%`);
+    adjustMaxWidth(widthValue);
+    saveSettings(widthValue);
+  });
 }

--- a/content.js
+++ b/content.js
@@ -80,7 +80,8 @@ const adjustMaxWidth = (width = 100) => {
 
         /* Override table container margins added by ChatGPT */
         div[class^='_tableContainer'] {
-            --thread-content-width: unset !important;
+            --thread-gutter-size: unset !important;
+            width: unset !important;
         }
 
         /* Ensure table wrapper matches selected width */

--- a/manifest.json
+++ b/manifest.json
@@ -1,16 +1,14 @@
 {
   "manifest_version": 3,
   "name": "WideGPT",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Scale Chat-GPT output to 100% width.",
   "browser_specific_settings": {
     "gecko": {
       "id": "{354273a1-bbac-450b-95d2-10700836bba2}"
     }
   },
-  "permissions": [
-    "storage"
-  ],
+  "permissions": ["storage"],
   "action": {
     "default_popup": "popup.html"
   },
@@ -19,12 +17,8 @@
   },
   "content_scripts": [
     {
-      "matches": [
-        "*://*.chatgpt.com/*"
-      ],
-      "js": [
-        "content.js"
-      ]
+      "matches": ["*://*.chatgpt.com/*"],
+      "js": ["content.js"]
     }
   ]
 }


### PR DESCRIPTION
**Description:**
This PR removes ChatGPT’s built-in table container margins and makes the table wrapper respect the user-configured width.
- unsets ` --thread-gutter-size` for tables
- unsets `width` for tables
- set width for table wrapper

**Test Procedures:**

1. Checkout branch
2. Click on "Load Temporary Add-on…" and open the folder containing WideGPT's source.
3. Select the manifest.json file from this branch's directory and click "Open" to install the add-on.
4. Observe that tables now start flush with the left gutter and scale to the selected percentage.

[Fixes #3](https://github.com/JThyroff/WideGPT/issues/3)
